### PR TITLE
Create Logger Singleton and default Configuration

### DIFF
--- a/Juliet/Configuration.swift
+++ b/Juliet/Configuration.swift
@@ -33,7 +33,9 @@ public protocol Configurable {
 }
 
 public struct Configuration : Configurable {
-    
+	
+	public static let defaultConfiguation: Configuration = Configuration()
+	
     public var levels : [LogLevel]
     
     public var exportFormat : ExportFormat

--- a/Juliet/Logger.swift
+++ b/Juliet/Logger.swift
@@ -23,7 +23,9 @@
 import Foundation
 
 open class Logger {
-    
+	
+	static let shared: Logger = Logger(configuration: Configuration.defaultConfiguation)
+	
     open var enabled : Bool = true
     
     open var configuration : Configurable


### PR DESCRIPTION
implements #17 

The shared singleton in Logger requires an initial configuration.

I added a singleton to Configuration
```swift
public static let defaultConfiguation: Configuration = Configuration()
```
Creating a singleton in Configuration allows me to access the private init method declared in the class.
```swift
private init() {
        self.levels =  [LogLevel.noerror, LogLevel.warning, LogLevel.alert, LogLevel.error, LogLevel.fatal]
        self.exportFormat = .json
        self.composerType = .console
    }
```
This means that the the Logger singleton can be initialized as so:
```swift
static let shared: Logger = Logger(configuration: Configuration.defaultConfiguation)
```